### PR TITLE
Unify collapsible section styling and behavior

### DIFF
--- a/js/data-render.js
+++ b/js/data-render.js
@@ -18,6 +18,21 @@ function allowCodeTags(s) {
         .replaceAll("&lt;/code&gt;", "</code>");
 }
 
+function slugify(str) {
+    return (str == null ? '' : String(str))
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}
+
+let sectionIdSeq = 0;
+
+function nextSectionDomId(base) {
+    const slug = slugify(base) || 'section';
+    sectionIdSeq += 1;
+    return `${slug}-${sectionIdSeq}`;
+}
+
 /* Row model */
 /**
  * @typedef {Object} Row
@@ -93,15 +108,21 @@ function renderRow(row) {
 function renderAttributeTable(section) {
     const s = (section && typeof section === 'object') ? section : {};
     const title = escHtml(s.title || '');
+    const idSource = (typeof s.id === 'string' && s.id.trim()) ? s.id : (s.title || 'section');
+    const domId = nextSectionDomId(idSource);
+    const headerId = `${domId}-header`;
+    const contentId = `${domId}-content`;
+    const dataKey = slugify(idSource);
+    const sectionAttrs = `class="collapsible-section" id="${escHtml(domId)}"${dataKey ? ` data-section-key="${escHtml(dataKey)}"` : ''}`;
 
     if (typeof s.html === 'string' && s.html.trim()) {
         let out = '';
-        out += '<section>';
-        out +=   '<h2 class="section-header">';
+        out += `<section ${sectionAttrs}>`;
+        out +=   `<h2 class="section-header" id="${escHtml(headerId)}" role="button" tabindex="0" aria-expanded="true" aria-controls="${escHtml(contentId)}">`;
         out +=     '<span class="toggle-icon">-</span>';
         out +=     '<span class="section-title">' + title + '</span>';
         out +=   '</h2>';
-        out +=   '<div class="section-content expanded">';
+        out +=   `<div class="section-content expanded" id="${escHtml(contentId)}" role="region" aria-hidden="false" aria-labelledby="${escHtml(headerId)}">`;
         out +=     s.html;
         out +=   '</div>';
         out += '</section>';
@@ -120,12 +141,12 @@ function renderAttributeTable(section) {
     tbody += '</tbody>';
 
     let out = '';
-    out += '<section>';
-    out +=   '<h2 class="section-header">';
+    out += `<section ${sectionAttrs}>`;
+    out +=   `<h2 class="section-header" id="${escHtml(headerId)}" role="button" tabindex="0" aria-expanded="true" aria-controls="${escHtml(contentId)}">`;
     out +=     '<span class="toggle-icon">-</span>';
     out +=     '<span class="section-title">' + title + '</span>';
     out +=   '</h2>';
-    out +=   '<div class="section-content expanded">';
+    out +=   `<div class="section-content expanded" id="${escHtml(contentId)}" role="region" aria-hidden="false" aria-labelledby="${escHtml(headerId)}">`;
     out +=     '<table>' + thead + tbody + '</table>';
     out +=   '</div>';
     out += '</section>';

--- a/js/script.js
+++ b/js/script.js
@@ -60,19 +60,30 @@ document.addEventListener('DOMContentLoaded', () => {
         try { localStorage.setItem(keyForHeader(header), expanded ? '1' : '0'); } catch {}
     }
 
+    function setSectionExpanded(header, expand, {persist = false, recalc = false} = {}) {
+        if (!header) return;
+        const content = header.nextElementSibling;
+        if (!content) return;
+        const icon = header.querySelector('.toggle-icon');
+
+        const shouldExpand = !!expand;
+        content.classList.toggle('expanded', shouldExpand);
+        content.setAttribute('aria-hidden', shouldExpand ? 'false' : 'true');
+        header.setAttribute('aria-expanded', shouldExpand ? 'true' : 'false');
+        if (icon) icon.textContent = shouldExpand ? '-' : '+';
+
+        if (persist) saveCollapseState(header, shouldExpand);
+        if (recalc && typeof recalcPageHeight === 'function') recalcPageHeight();
+    }
+
     function restoreAllCollapseStates() {
         document.querySelectorAll('.content-section').forEach(mount => {
             mount.querySelectorAll('.section-header').forEach(header => {
-                const content = header.nextElementSibling;
-                const icon    = header.querySelector('.toggle-icon');
-                if (!content) return;
-
                 const key     = keyForHeader(header);
                 const stored  = localStorage.getItem(key);
                 const expand  = stored === null ? true : stored === '1';
 
-                content.classList.toggle('expanded', expand);
-                if (icon) icon.textContent = expand ? '-' : '+';
+                setSectionExpanded(header, expand);
             });
         });
         if (typeof recalcPageHeight === 'function') recalcPageHeight();
@@ -423,21 +434,34 @@ document.addEventListener('DOMContentLoaded', () => {
     
     
     /* Expand or collapse sections and persist the state */
-    document.addEventListener('click', (e) => {
-        const target = $closest(e.target,'.section-header .section-title, .section-header .toggle-icon');
-        if (!target) return;
+    function headerClickTargetsDocLink(eventTarget) {
+        return !!$closest(eventTarget, '.doc-icon-link');
+    }
 
-        const header  = target.closest('.section-header');
-        const content = header?.nextElementSibling;
-        const icon    = header?.querySelector('.toggle-icon');
+    document.addEventListener('click', (e) => {
+        const header = $closest(e.target, '.section-header');
+        if (!header) return;
+        if (headerClickTargetsDocLink(e.target)) return;
+
+        const content = header.nextElementSibling;
         if (!content) return;
 
-        const expanded = content.classList.toggle('expanded');
-        if (icon) icon.textContent = expanded ? '-' : '+';
+        const expanded = !content.classList.contains('expanded');
+        setSectionExpanded(header, expanded, {persist: true, recalc: true});
+    });
 
-        saveCollapseState(header, expanded);
+    document.addEventListener('keydown', (e) => {
+        if (e.key !== 'Enter' && e.key !== ' ') return;
+        const header = $closest(e.target, '.section-header');
+        if (!header) return;
+        if (headerClickTargetsDocLink(e.target)) return;
 
-        if (typeof recalcPageHeight === 'function') recalcPageHeight();
+        const content = header.nextElementSibling;
+        if (!content) return;
+
+        e.preventDefault();
+        const expanded = !content.classList.contains('expanded');
+        setSectionExpanded(header, expanded, {persist: true, recalc: true});
     });
 
 

--- a/style.css
+++ b/style.css
@@ -602,7 +602,7 @@ th, td {
     align-items: center;
     gap: 0.5rem;
     font-size: 1.2rem;
-    cursor: default;
+    cursor: pointer;
 }
 
 .section-header .section-title,
@@ -624,14 +624,89 @@ th, td {
     overflow: hidden;
     max-height: 0;
     transition: max-height 0.4s ease, padding 0.4s ease;
-    padding: 0 1rem;
-    margin-bottom: 2rem;
+    padding: 0;
 }
 
 /* Expanded state */
 .section-content.expanded {
-    max-height: 1000px;
-    padding: 1rem;
+    max-height: 1200px;
+}
+
+.collapsible-section {
+    margin: 14px 0;
+    border-radius: 14px;
+    background: color-mix(in oklab, var(--bg-secondary) 92%, black 8%);
+    border: 1px solid color-mix(in oklab, var(--border-muted) 80%, white 20%);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.22), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+    overflow: hidden;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.light-theme .collapsible-section {
+    background: color-mix(in oklab, var(--bg-secondary) 92%, white 8%);
+    border-color: color-mix(in oklab, var(--border-muted) 70%, white 30%);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.65);
+}
+
+.collapsible-section:hover,
+.collapsible-section:focus-within {
+    border-color: color-mix(in oklab, var(--border-muted) 60%, var(--accent) 40%);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.28), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.light-theme .collapsible-section:hover,
+.light-theme .collapsible-section:focus-within {
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.18), inset 0 1px 0 rgba(255, 255, 255, 0.75);
+}
+
+.collapsible-section .section-header {
+    padding: 12px 14px;
+    background: transparent;
+    font-weight: 600;
+    letter-spacing: 0;
+    border-bottom: 1px solid color-mix(in oklab, var(--border-muted) 70%, transparent 30%);
+}
+
+.collapsible-section .section-header:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
+.collapsible-section .toggle-icon {
+    width: 22px;
+    height: 22px;
+    line-height: 22px;
+    text-align: center;
+    border-radius: 8px;
+    opacity: 0.85;
+}
+
+.collapsible-section .section-content {
+    padding: 0 14px;
+    background: color-mix(in oklab, var(--bg-secondary) 95%, black 5%);
+}
+
+.light-theme .collapsible-section .section-content {
+    background: color-mix(in oklab, var(--bg-secondary) 96%, white 4%);
+}
+
+.collapsible-section .section-content.expanded {
+    padding: 10px 14px 14px;
+    border-top: 1px solid color-mix(in oklab, var(--border-muted) 65%, transparent 35%);
+}
+
+.collapsible-section .section-header .doc-icon-link,
+.collapsible-section .section-header .doc-link {
+    margin-left: auto;
+    opacity: 0.6;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    transform: translateY(0);
+}
+
+.collapsible-section .section-header .doc-icon-link:hover,
+.collapsible-section .section-header .doc-link:hover {
+    opacity: 1;
+    transform: translateY(-1px);
 }
 
 /* The question mark icon link (separate) */
@@ -832,57 +907,6 @@ th, td {
     min-height: 2.8em;
 }
     
-    /* "Other" tab polish */
-    #otherSection section {
-        margin: 14px 0;
-        border-radius: 14px;
-        background: linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.02));
-        box-shadow: 0 6px 16px rgba(0,0,0,0.22), inset 0 1px 0 rgba(255,255,255,0.04);
-        border: 1px solid rgba(255,255,255,0.08);
-        overflow: hidden;
-    }
-
-    #otherSection .section-header {
-        display: flex;
-        align-items: center;
-        gap: .5rem;
-        padding: 12px 14px;
-        background: transparent;
-    }
-
-    #otherSection .section-header .section-title {
-        font-weight: 600;
-        letter-spacing: 0;
-    }
-
-    #otherSection .toggle-icon {
-        width: 22px;
-        height: 22px;
-        line-height: 22px;
-        text-align: center;
-        border-radius: 8px;
-        opacity: .8;
-        user-select: none;
-    }
-
-    #otherSection .section-content {
-        padding: 10px 14px 14px;
-    }
-
-    /* Put the docs ? on the header, right-aligned, subtle */
-    #otherSection .section-header .doc-icon-link,
-    #otherSection .section-header .doc-link {
-        margin-left: auto;
-        opacity: .6;
-        transition: opacity .2s ease, transform .2s ease;
-        transform: translateY(0);
-    }
-    #otherSection .section-header .doc-icon-link:hover,
-    #otherSection .section-header .doc-link:hover {
-        opacity: 1;
-        transform: translateY(-1px);
-    }
-
     /* Code block aesthetics */
     #otherSection pre {
         margin: 10px 0 0;
@@ -897,12 +921,6 @@ th, td {
         font-size: 0.92rem;
         line-height: 1.4;
         white-space: pre;
-    }
-
-    /* Small glow on hover for the whole card */
-    #otherSection section:hover {
-        box-shadow: 0 10px 24px rgba(0,0,0,0.28), inset 0 1px 0 rgba(255,255,255,0.06);
-        border-color: rgba(255,255,255,0.12);
     }
 
     /* Hide the native disclosure marker across engines */


### PR DESCRIPTION
## Summary
- give every rendered section a shared card wrapper with button-like headers and ARIA hooks
- reuse the collapse persistence logic to drive aria-expanded/hidden states and enable full-header click & keyboard toggles
- restyle collapsible sections so Unity/C#/Sites cards match the existing Misc look and hover treatments

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e179dddfb0833193826fdcb465f6ff