### PR TITLE
Allow sections to show related resource cards

### DIFF
--- a/data/csharp.json
+++ b/data/csharp.json
@@ -4,6 +4,19 @@
       "id": "interop",
       "title": "C# Language & Interop Attributes",
       "columns": ["Attribute", "Description", "Requirements"],
+      "siteTitle": "C# Resources",
+      "sites": [
+        {
+          "title": "C# Attribute Reference",
+          "url": "https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/attributes/",
+          "description": "Overview of built-in C# attribute types and usage guidelines."
+        },
+        {
+          "title": ".NET Documentation",
+          "url": "https://learn.microsoft.com/en-us/dotnet/",
+          "description": "Official .NET docs covering runtime libraries, APIs, and tooling."
+        }
+      ],
       "rows": [
         {
           "code": "[Serializable]",

--- a/data/unity.json
+++ b/data/unity.json
@@ -8,6 +8,19 @@
         "Description",
         "Requirements"
       ],
+      "siteTitle": "Unity Resources",
+      "sites": [
+        {
+          "title": "Unity Scripting API",
+          "url": "https://docs.unity3d.com/ScriptReference/",
+          "description": "Official API reference for Unity scripting attributes and components."
+        },
+        {
+          "title": "Unity Learn",
+          "url": "https://learn.unity.com/",
+          "description": "Self-paced tutorials and guided learning paths for Unity developers."
+        }
+      ],
       "rows": [
         {
           "code": "[SerializeField]",

--- a/style.css
+++ b/style.css
@@ -799,10 +799,10 @@ th, td {
 }
 
 /* Useful Sites cards */
-#siteGrid .site-link,
-#siteGrid .site-link:hover,
-#siteGrid .site-link:focus,
-#siteGrid .site-link:active {
+.site-grid .site-link,
+.site-grid .site-link:hover,
+.site-grid .site-link:focus,
+.site-grid .site-link:active {
     text-decoration: none;
 }
 
@@ -814,6 +814,20 @@ th, td {
     display: grid;
     gap: 16px;
     grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+}
+
+.section-sites {
+    margin-top: 24px;
+}
+
+.section-sites-title {
+    margin: 0;
+    font-size: clamp(1.05rem, 1.2vw + 1rem, 1.25rem);
+    font-weight: 600;
+}
+
+.section-sites .site-grid {
+    margin: 16px 0 0;
 }
 
 .site-card {


### PR DESCRIPTION
## Summary
- allow attribute sections to define optional related site resources that render as cards
- add Unity and C# resource examples using the new section-specific site support
- generalize site card styles so the layout works across dedicated and embedded grids

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e189367fd48331a252aeaa2d1477cd