### PR TITLE
Use shared site cards across sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,25 +118,25 @@
 
 <!-- Useful Sites -->
 <!-- Filled dynamically from /data/sites.json -->
+<template id="siteCardTpl">
+    <li class="site-card">
+        <a class="site-link" target="_blank" rel="noopener">
+            <div class="thumb">
+                <div class="thumb-overlay"></div>
+                <img class="thumb-icon" alt="" loading="lazy" decoding="async" />
+            </div>
+            <div class="info">
+                <div class="title-line">
+                    <h3 class="title"></h3>
+                </div>
+                <p class="desc"></p>
+                <div class="tags"></div>
+            </div>
+        </a>
+    </li>
+</template>
 <div id="sitesSection" class="content-section" style="display:none;">
     <ul id="siteGrid" class="site-grid"></ul>
-    <template id="siteCardTpl">
-        <li class="site-card">
-            <a class="site-link" target="_blank" rel="noopener">
-                <div class="thumb">
-                    <div class="thumb-overlay"></div>
-                    <img class="thumb-icon" alt="" loading="lazy" decoding="async" />
-                </div>
-                <div class="info">
-                    <div class="title-line">
-                        <h3 class="title"></h3>
-                    </div>
-                    <p class="desc"></p>
-                    <div class="tags"></div>
-                </div>
-            </a>
-        </li>
-    </template>
 </div>
 
 <!-- BACK TO TOP -->


### PR DESCRIPTION
## Summary
- move the site card template outside of the standalone section so every dataset can reuse the same markup
- centralize rendering of resource card wrappers and hydrate them for section and global site lists
- ensure data attributes are escaped correctly so Blender resource cards adopt the reusable site card style

## Testing
- manual: python3 -m http.server 8000 (verified Blender section site cards render with shared design)


------
https://chatgpt.com/codex/tasks/task_e_68e193d5dcd08331909754dad78e53e1