### PR TITLE
Show Useful Sites cards without collapse

### DIFF
--- a/js/data-render.js
+++ b/js/data-render.js
@@ -208,20 +208,21 @@ function renderStandaloneSitesSection(opts) {
     if (!normalizedSections.length) return '';
 
     const domId = nextSectionDomId(idSource);
-    const headerId = `${domId}-header`;
-    const contentId = `${domId}-content`;
     const dataKey = slugify(idSource);
     const introHtml = hasExplicitSections && descriptionText
         ? `<p class="section-sites-desc section-sites-intro">${allowCodeTags(descriptionText)}</p>`
         : '';
+    const descriptionHtml = !hasExplicitSections && descriptionText
+        ? `<p class="section-sites-desc">${allowCodeTags(descriptionText)}</p>`
+        : '';
 
     let out = '';
-    out += `<section class="collapsible-section" id="${escHtml(domId)}"${dataKey ? ` data-section-key="${escHtml(dataKey)}"` : ''}>`;
-    out +=   `<h2 class="section-header" id="${escHtml(headerId)}" role="button" tabindex="0" aria-expanded="true" aria-controls="${escHtml(contentId)}">`;
-    out +=     '<span class="toggle-icon">-</span>';
-    out +=     `<span class="section-title">${escHtml(titleText)}</span>`;
-    out +=   '</h2>';
-    out +=   `<div class="section-content expanded" id="${escHtml(contentId)}" role="region" aria-hidden="false" aria-labelledby="${escHtml(headerId)}">`;
+    out += `<section class="sites-section" id="${escHtml(domId)}"${dataKey ? ` data-section-key="${escHtml(dataKey)}"` : ''}>`;
+    out +=   '<div class="sites-section-header">';
+    out +=     `<h2 class="sites-section-title">${escHtml(titleText)}</h2>`;
+    out +=   '</div>';
+    out +=   '<div class="sites-section-body">';
+    out +=     descriptionHtml;
     out +=     introHtml;
 
     for (const section of normalizedSections) {

--- a/style.css
+++ b/style.css
@@ -748,6 +748,50 @@ th, td {
     transform: translateY(-1px);
 }
 
+/* Standalone Useful Sites section */
+.sites-section {
+    margin: 14px 0;
+    padding: 22px 24px 28px;
+    border-radius: 16px;
+    background: color-mix(in oklab, var(--bg-secondary) 92%, black 8%);
+    border: 1px solid color-mix(in oklab, var(--border-muted) 80%, white 20%);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.22), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.light-theme .sites-section {
+    background: color-mix(in oklab, var(--bg-secondary) 92%, white 8%);
+    border-color: color-mix(in oklab, var(--border-muted) 70%, white 30%);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.65);
+}
+
+.sites-section-header {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    margin-bottom: 12px;
+}
+
+.sites-section-title {
+    margin: 0;
+    font-weight: 650;
+    font-size: clamp(1.35rem, 1vw + 1.15rem, 1.65rem);
+    letter-spacing: -0.01em;
+}
+
+.sites-section-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+}
+
+.sites-section-body > .section-sites-desc {
+    margin: 0 0 16px;
+}
+
+.sites-section-body > .section-sites-intro {
+    margin-top: 0;
+}
+
 /* The question mark icon link (separate) */
 .doc-icon-link {
     cursor: pointer;


### PR DESCRIPTION
## Summary
- render the Useful Sites tab without wrapping the cards in a collapsible section
- add a static section header/body layout and matching styles for the Useful Sites grid

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e19b0962e08331808124d4454dbd6b